### PR TITLE
Hyperlink edge cases

### DIFF
--- a/lib/docx/body-reader.js
+++ b/lib/docx/body-reader.js
@@ -21,6 +21,7 @@ function createBodyReader(options) {
 
 function BodyReader(options) {
     var fieldHyperlink = null;
+    var currentInstrText = [];
     var relationships = options.relationships;
     var contentTypes = options.contentTypes;
     var docxFile = options.docxFile;
@@ -159,14 +160,17 @@ function BodyReader(options) {
             var type = element.attributes["w:fldCharType"];
             if (type === "end") {
                 fieldHyperlink = null;
+            } else if (type === "separate") {
+                var hyperlink = parseHyperlinkFieldCode(currentInstrText.join(''));
+                if (hyperlink !== null) {
+                    fieldHyperlink = hyperlink;
+                }
+                currentInstrText = [];
             }
             return emptyResult();
         },
         "w:instrText": function(element) {
-            var hyperlink = parseHyperlinkFieldCode(element.text());
-            if (hyperlink !== null) {
-                fieldHyperlink = hyperlink;
-            }
+            currentInstrText.push(element.text());
             return emptyResult();
         },
         "w:t": function(element) {

--- a/lib/docx/body-reader.js
+++ b/lib/docx/body-reader.js
@@ -20,7 +20,7 @@ function createBodyReader(options) {
 }
 
 function BodyReader(options) {
-    var fieldHyperlink = null;
+    var fieldHyperlinks = [];
     var currentInstrText = [];
     var relationships = options.relationships;
     var contentTypes = options.contentTypes;
@@ -148,8 +148,9 @@ function BodyReader(options) {
                     var properties = _.find(children, isRunProperties);
                     children = children.filter(negate(isRunProperties));
 
-                    if (fieldHyperlink !== null) {
-                        children = [new documents.Hyperlink(children, {href: fieldHyperlink})];
+                    var validFieldHyperlinks = _.compact(fieldHyperlinks);
+                    if (validFieldHyperlinks.length !== 0) {
+                        children = [new documents.Hyperlink(children, {href: _.last(validFieldHyperlinks)})];
                     }
 
                     return new documents.Run(children, properties);
@@ -159,12 +160,10 @@ function BodyReader(options) {
         "w:fldChar": function(element) {
             var type = element.attributes["w:fldCharType"];
             if (type === "end") {
-                fieldHyperlink = null;
+                fieldHyperlinks.pop();
             } else if (type === "separate") {
                 var hyperlink = parseHyperlinkFieldCode(currentInstrText.join(''));
-                if (hyperlink !== null) {
-                    fieldHyperlink = hyperlink;
-                }
+                fieldHyperlinks.push(hyperlink);
                 currentInstrText = [];
             }
             return emptyResult();

--- a/lib/docx/body-reader.js
+++ b/lib/docx/body-reader.js
@@ -20,7 +20,7 @@ function createBodyReader(options) {
 }
 
 function BodyReader(options) {
-    var fieldHyperlinks = [];
+    var complexFields = [];
     var currentInstrText = [];
     var relationships = options.relationships;
     var contentTypes = options.contentTypes;
@@ -148,9 +148,9 @@ function BodyReader(options) {
                     var properties = _.find(children, isRunProperties);
                     children = children.filter(negate(isRunProperties));
 
-                    var validFieldHyperlinks = _.compact(fieldHyperlinks);
-                    if (validFieldHyperlinks.length !== 0) {
-                        children = [new documents.Hyperlink(children, {href: _.last(validFieldHyperlinks)})];
+                    var scopedHyperlink = scopedComplexFieldOfType(complexFields, "hyperlink");
+                    if (scopedHyperlink !== undefined) {
+                        children = [new documents.Hyperlink(children, {href: scopedHyperlink.href})];
                     }
 
                     return new documents.Run(children, properties);
@@ -160,10 +160,14 @@ function BodyReader(options) {
         "w:fldChar": function(element) {
             var type = element.attributes["w:fldCharType"];
             if (type === "end") {
-                fieldHyperlinks.pop();
+                complexFields.pop();
             } else if (type === "separate") {
-                var hyperlink = parseHyperlinkFieldCode(currentInstrText.join(''));
-                fieldHyperlinks.push(hyperlink);
+                var href = parseHyperlinkFieldCode(currentInstrText.join(''));
+                if (href !== null) {
+                    complexFields.push({type: "hyperlink", href: href});
+                } else {
+                    complexFields.push(null);
+                }
                 currentInstrText = [];
             }
             return emptyResult();
@@ -532,4 +536,14 @@ function parseHyperlinkFieldCode(code) {
     } else {
         return null;
     }
+}
+
+function complexFieldsOfType(complexFields, type) {
+    return complexFields.filter(function(complexField) {
+        return complexField.type === type;
+    });
+}
+
+function scopedComplexFieldOfType(complexFields, type) {
+    return _.last(complexFieldsOfType(complexFields, type));
 }

--- a/test/docx/body-reader.tests.js
+++ b/test/docx/body-reader.tests.js
@@ -308,6 +308,55 @@ test("complex fields", (function() {
                 }),
                 isEmptyRun
           ));
+        },
+
+        "complex field nested within a hyperlink complex field is wrapped with the hyperlink": function() {
+            var authorInstrText = new XmlElement("w:instrText", {}, [
+                xml.text(' AUTHOR "John Doe"')
+            ]);
+            var paragraphXml = new XmlElement("w:p", {}, [
+                beginXml,
+                hyperlinkInstrText,
+                separateXml,
+                hyperlinkRunXml,
+                beginXml,
+                authorInstrText,
+                endXml,
+                endXml
+            ]);
+            var paragraph = readXmlElementValue(paragraphXml);
+
+            assertThat(paragraph.children, contains(
+                isEmptyRun,
+                isRun({
+                    children: contains(
+                        isHyperlink({
+                            href: uri,
+                            children: []
+                        })
+                    )
+                }),
+                isRun({
+                    children: contains(
+                        isHyperlink({
+                            href: uri,
+                            children: contains(
+                                isText("this is a hyperlink")
+                            )
+                        })
+                    )
+                }),
+                isRun({
+                    children: contains(
+                        isHyperlink({
+                            href: uri,
+                            children: []
+                        })
+                    )
+                }),
+                isEmptyRun,
+                isEmptyRun
+          ));
         }
     };
 })());

--- a/test/docx/body-reader.tests.js
+++ b/test/docx/body-reader.tests.js
@@ -154,6 +154,7 @@ test("complex fields", (function() {
     var hyperlinkInstrText = new XmlElement("w:instrText", {}, [
         xml.text(' HYPERLINK "' + uri + '"')
     ]);
+    var hyperlinkRunXml = runOfText("this is a hyperlink");
     
     return {
         "stores instrText returns empty result": function() {
@@ -227,7 +228,6 @@ test("complex fields", (function() {
         },
 
         "can handle split instrText elements": function() {
-            var hyperlinkRunXml = runOfText("this is a hyperlink");
             var hyperlinkInstrTextPart1 = new XmlElement("w:instrText", {}, [
                 xml.text(" HYPE")
             ]);
@@ -266,6 +266,48 @@ test("complex fields", (function() {
                 }),
                 isEmptyRun
             ));
+        },
+
+        "hyperlink with a nested complex field uses the outer hyperlink": function() {
+            var authorInstrText = new XmlElement("w:instrText", {}, [
+                xml.text(' AUTHOR "John Doe"')
+            ]);
+            var paragraphXml = new XmlElement("w:p", {}, [
+                beginXml,
+                beginXml,
+                authorInstrText,
+                endXml,
+                hyperlinkInstrText,
+                separateXml,
+                hyperlinkRunXml,
+                endXml
+            ]);
+            var paragraph = readXmlElementValue(paragraphXml);
+
+            assertThat(paragraph.children, contains(
+                isEmptyRun,
+                isEmptyRun,
+                isEmptyRun,
+                isRun({
+                    children: contains(
+                        isHyperlink({
+                            href: uri,
+                            children: []
+                        })
+                    )
+                }),
+                isRun({
+                    children: contains(
+                        isHyperlink({
+                            href: uri,
+                            children: contains(
+                                isText("this is a hyperlink")
+                            )
+                        })
+                    )
+                }),
+                isEmptyRun
+          ));
         }
     };
 })());


### PR DESCRIPTION
This targets the WIP (https://github.com/mwilliamson/mammoth.js/pull/110), but I am opening this up separately for discussion because I feel there could be some improvement in these solutions and I may have missed other edge cases.

## Nested Complex fields

This seems to be easily handled by making `fieldHyperlink` an array `fieldHyperlinks` and using the array like a stack. Every time we hit `end` we can pop the most recent field off the stack, etc. The problem here, is that we only care about hyperlink complex fields, but there is no real way to differentiate them from the complex fields we don't care about (since begin/end blocks don't notate what they are for). I think the easiest way would be to push null onto the stack for other complex fields and filter out the nulls before usage. I am not a huge fan of this approach, but it keeps the push/pop behavior simple.

## Split instrText Elements

Obviously we will have to build up the string before parsing it. I generally use an array and then join the items once my string is built rather than concatenating strings since strings are immutable, but if that goes against the style of the codebase, I am happy to concat the strings.

I am thinking this would also introduce another item of state to store the current `instrText` that is being built (`currentInstrText` or something like that). We could also just build it inside the `fieldHyperlinks` array, but I think it is safer and easier to see what is happening if we don't add the data to this array until we hit a `<w:fldChar w:fldCharType="separate"/>` tag AND if we are able to parse it with our hyperlink parser.

**The assumption made here is that the `<w:fldChar w:fldCharType="separate"/>` field is always included. I have not been able to generate docx with Word without it, but I am not sure if the field is optional or not. If it is optional, this solution will definitely need to handle this case.

## URI Encoding

Looks like the URI's are not encoded at all (spaces will just be spaces) and are stored inside of double quotes. If there are double quotes in the URI (which I don't even think is a valid URI), but the docx will just escape those quotes. The regex already handles this, so we are fine here.